### PR TITLE
fix ordering of variable declarations

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -43,12 +43,6 @@ function establishMessageChannel(repo) {
   navigator.serviceWorker.controller.postMessage({ type: "INIT_PORT" }, [messageChannel.port2])
 }
 
-// Re-establish the MessageChannel if the controlling service worker changes
-navigator.serviceWorker.oncontrollerchange = function () {
-  console.log("Controller changed!")
-  establishMessageChannel(repo)
-}
-
 // (Actually do the things above here.)
 await setupServiceWorker()
 const repo = await setupRepo()
@@ -69,6 +63,12 @@ window.process = {
   versions: {},
   stderr: {},
   cwd: () => ".",
+}
+
+// Re-establish the MessageChannel if the controlling service worker changes
+navigator.serviceWorker.oncontrollerchange = function () {
+  console.log("Controller changed!")
+  establishMessageChannel(repo)
 }
 
 async function bootstrapApplication() {


### PR DESCRIPTION
repo was being used before it was declared, causing a crash on launch.

Previously on boot I saw the error message in console `Uncaught ReferenceError: Cannot access 'repo' before initialization at navigator.serviceWorker. oncontrollerchange (index.is:49:27)`, after this change it's gone.